### PR TITLE
Add detailed comments to OmniProcessId variables

### DIFF
--- a/src/main/java/br/com/myvirtualhub/omni/commons/core/OmniProcessId.java
+++ b/src/main/java/br/com/myvirtualhub/omni/commons/core/OmniProcessId.java
@@ -25,10 +25,28 @@ import java.util.UUID;
  */
 public abstract class OmniProcessId implements Serializable, Copyable<OmniProcessId> {
 
+    /**
+     * Represents the prefix associated with an OmniProcessId.
+     * The prefix is a string value that is associated with an OmniProcessId object.
+     * It is used to identify and categorize the OmniProcessId.
+     * The prefix can be retrieved using the {@link OmniProcessId#getPrefix()} method.
+     * For example, if the prefix is "ABC123", it can be used to differentiate the OmniProcessId from others.
+     *
+     * @see OmniProcessId
+     * @see OmniProcessId#getPrefix()
+     */
     private final String prefix;
 
+    /**
+     * Represents the channel type associated with an OmniProcessId.
+     * The channel type is used to determine how to process and handle communications based on the specific channel.
+     * This information is typically used throughout the system.
+     */
     private final ChannelType channelType;
 
+    /**
+     * The omniProcessUUID variable represents the universally unique identifier (UUID) associated with the OmniProcessId.
+     */
     private final UUID omniProcessUUID;
 
     /**


### PR DESCRIPTION
Added comprehensive comments to the variables in the OmniProcessId class clarifying their functions. This includes explanations for 'prefix', 'channelType', and 'omniProcessUUID' variables, enhancing code readability and maintainability.